### PR TITLE
`remove_snp_probes`: no conda channels

### DIFF
--- a/modules/local/remove_snp_probes/environment.yml
+++ b/modules/local/remove_snp_probes/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - bioconda::bioconductor-illuminahumanmethylation450kmanifest=0.4.0
   - bioconda::bioconductor-IlluminaHumanMethylation450kanno.ilmn12.hg19=0.6.1
   - anaconda::libopenblas=0.3.3
-  - conda-forge:r-readr=2.1.5
+  - conda-forge::r-readr=2.1.5


### PR DESCRIPTION
PR to address the typo described in https://github.com/nf-core/methylarray/issues/30

I'm a bit wary of the pinned `anaconda` channel, which may cause problems for people due to Anaconda's usage policies. It looks like conda-forge has a version of the same library: https://anaconda.org/conda-forge/libopenblas - but the versions only go back to 0.3.6. Is there a reason to (a) use such an old version of the library and (b) pin `anaconda`?

